### PR TITLE
Fix storage-initializer-docker-publisher workflow

### DIFF
--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -88,7 +88,7 @@ jobs:
           TAGS=$IMAGE_ID:$VERSION
           # If a vX.Y.Z release is being built, also update the vX.Y tag.
           [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && MINOR_VERSION=$(echo $VERSION | sed 's/\(.*\)\.[[:digit:]]\+$/\1/')
-          [ ! -z "env.MINOR_VERSION" ] && TAGS=$TAGS,$IMAGE_ID:$MINOR_VERSION
+          [ ! -z "$MINOR_VERSION" ] && TAGS=$TAGS,$IMAGE_ID:$MINOR_VERSION
           
           echo TAGS=$TAGS >> $GITHUB_ENV
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an error in the storage-initializer-docker-publisher workflow where a string is being used, but should be a variable. On PR merges, this is causing an error when trying to push the docker image of the storage initializer.

This is fixing the issue by properly using the variable.

